### PR TITLE
Update Sei gas limit to 800000

### DIFF
--- a/src/hooks/useHandleRedeem.tsx
+++ b/src/hooks/useHandleRedeem.tsx
@@ -418,7 +418,7 @@ async function sei(
       },
     };
     // TODO: is this right?
-    const fee = calculateFee(750000, "0.1usei");
+    const fee = calculateFee(800000, "0.1usei");
     const tx = await wallet.execute(
       walletAddress,
       SEI_TRANSLATOR,


### PR DESCRIPTION
750000 gas limit fails with error:
```
Error when broadcasting tx 034CC9F1D9704B5E944D490EBE5B3796501688F022178AE362CAB947C09202F2 at height 11473196. Code: 11; Raw log: out of gas in location: ReadFlat; gasWanted: 750000, gasUsed: 750962: out of gas
```

Updating this to 800000 in the wallet fixes this.