### PR TITLE
Fixed low ticker char count for MetaMask

### DIFF
--- a/src/components/Transfer/AddToMetamask.tsx
+++ b/src/components/Transfer/AddToMetamask.tsx
@@ -55,7 +55,7 @@ export default function AddToMetamask() {
                   symbol ||
                   sourceParsedTokenAccount?.symbol ||
                   "wh"
-                ).substr(0, 5), // A ticker symbol or shorthand, up to 5 characters
+                ).substr(0, 11), // A ticker symbol or shorthand, up to 11 characters
                 decimals, // The number of token decimals
                 // image: string; // A string url of the token logo
               },


### PR DESCRIPTION
MetaMask now supports up to 11 characters in its symbols, not only 5. Now longer names like `xcMANTA` can be supported.

Thank you for helping with this issue @evan-gray 